### PR TITLE
Clean symbol type rep

### DIFF
--- a/commander-cli.cabal
+++ b/commander-cli.cabal
@@ -21,6 +21,7 @@ source-repository head
 
 library
   exposed-modules:     Options.Commander
+                       Options.Commander.Internal
   other-extensions:    ViewPatterns,
                        DerivingVia,
                        StandaloneDeriving,

--- a/src/Options/Commander/Internal.hs
+++ b/src/Options/Commander/Internal.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Options.Commander.Internal where
+
+import Data.Proxy (Proxy(Proxy))
+import Data.String (IsString(fromString))
+import Data.Typeable (Typeable, typeRep)
+import GHC.TypeLits (Symbol, KnownSymbol, symbolVal)
+
+
+showSymbol :: forall (a :: Symbol) b. (KnownSymbol a, IsString b) => b
+showSymbol = fromString $ symbolVal $ Proxy @a
+
+showTypeRep :: forall a b. (Typeable a, IsString b) => b
+showTypeRep = fromString $ show $ typeRep $ Proxy @a
+


### PR DESCRIPTION
when creating documentation there was a lot of boilerplate that obfuscated the intent of what documentation was being created. I created helper functions that made things clearer.